### PR TITLE
add: leetcode - 146 lru cache #77

### DIFF
--- a/Leetcode/146-lru-cache/SeungukLee/solution.py
+++ b/Leetcode/146-lru-cache/SeungukLee/solution.py
@@ -1,0 +1,77 @@
+class Node:
+    def __init__(self, key, value):
+        self.key = key
+        self.value = value
+        self.prev = None
+        self.next = None
+
+class LRUCache:
+    # double linkedlist + hashmap
+    def __init__(self, capacity: 'int'):
+        self.cap = capacity
+        self.head = None
+        self.tail = None
+        self.node_dict = {} # key: int, value: Node
+        
+    def get(self, key: 'int') -> 'int':
+        if key not in self.node_dict:
+            return -1
+        
+        cur = self.node_dict[key]
+        if cur != self.head:
+            if cur != self.tail:
+                # head -> node <-> node2 <-> node3
+                cur.prev.next = cur.next
+                cur.next.prev = cur.prev
+                self._insert_after_head(cur)
+            else:
+                cur.prev.next = None
+                self.tail = cur.prev
+                self._insert_after_head(cur)
+                
+        return self.node_dict[key].value
+    
+    def put(self, key: 'int', value: 'int') -> 'None':
+        if self.get(key) != -1:
+            # print("key in self.node_dict")
+            self.node_dict[key].value = value
+        else:
+            node = Node(key, value)
+            self.node_dict[key] = node
+            self._insert_after_head(node)
+        if self._is_spill_over():
+            self._pop_node(self.tail.key)
+        
+    def _insert_after_head(self, node: Node) -> None:
+        if self.head == None:
+            self.head = node
+            self.tail = node
+        else:
+            node.next = self.head
+            node.prev = None
+            self.head.prev = node
+            self.head = node
+            
+    def _is_spill_over(self) -> None:
+        return len(self.node_dict) > self.cap
+    
+    def _pop_node(self, key) -> None:
+        cur = self.tail
+        self.tail = cur.prev
+        cur.prev.next = None
+        cur.prev = None
+        self.node_dict.pop(key)
+   
+    def _print(self):
+        cur = self.head;
+        res = []
+        while cur != None:
+            res.append(str((cur.key, cur.value)))
+            cur = cur.next
+        print("->".join(res))
+
+# Your LRUCache object will be instantiated and called as such:
+# obj = LRUCache(capacity)
+# param_1 = obj.get(key)
+# obj.put(key,value)
+


### PR DESCRIPTION
#77 
새로운 값을 push 할려고 하는데 캐시의 사이즈가 넘치게 되었다고 하자. 가장 최근에 사용한 값들로 정렬한 경우 제일 마지막에 있는 값을 pop 하고 새로운 값을 push 하는 것을 LRU Cache 라고 한다.

즉, 해당 문제의 example 처럼 연산이 이루어진다면 캐시는 각 연산마다 다음과 같이 변하게 될 것이다.
```
// leetcode example
LRUCache cache = new LRUCache( 2 /* capacity */ );

cache.put(1, 1);
cache.put(2, 2);
cache.get(1);       // returns 1
cache.put(3, 3);    // evicts key 2
cache.get(2);       // returns -1 (not found)
cache.put(4, 4);    // evicts key 1
cache.get(1);       // returns -1 (not found)
cache.get(3);       // returns 3
cache.get(4);       // returns 4
```

```
(1,1)          // put(1,1)
(2,2) -> (1,1) // put(2,2)
(1,1) -> (2,2) // get(1)
(3,3) -> (1,1) // put(3,3)
(3,3) -> (1,1) // get(2) => "Not Found"
(4,4) -> (3,3) // put(4,4)
(4,4) -> (3,3) // get(1) => "Not Found"
(3,3) -> (4,4) // get(3)
(4,4) -> (3,3) // get(4)
```

LRU Cache 를 구현하려고 할 때 직감적으로 링크드 리스트를 이용하면 될 것 같다는 생각을 한다. 하지만 문제는 `get`, `put` operation 의 시간복잡도를 `O(1)` 로 하는 것이 핵심이다. 링크드 리스트는 탐색을 하는데 `O(N)` 의 시간복잡도를 가지기 때문에 좀 더 효율적으로 구현할 수 있는 방법을 생각해야한다. 내가 이용한 방법은 해쉬맵을 이용하는 것이다. 해쉬맵은 탐색하는데 `O(1)` 시간복잡도가 걸리기 때문에 링크드 리스트과 해쉬맵을 이용하면 LRU Cache 를 구현할 수 있다.

즉, 그림으로 표현하자면 다음과 같다.

![image](https://user-images.githubusercontent.com/21017537/79062328-5b022680-7cd4-11ea-85ae-33d91a197989.png)

링크드 리스트를 DLL (Doubly Linked List)로 사용하였는데 node 를 특정 위치에 삽입할 때 그 이전 노드(prev node)를 알아야하는데 SLL (Singly Linked List)로 사용하면 prev node 를 알기위해 탐색을 해야하기때문에 DLL을 이용하였다.

> 

